### PR TITLE
The number of downloaded files is not displayed correctly when printing receipts.

### DIFF
--- a/woocommerce-delivery-notes/templates/print-order/print-content.php
+++ b/woocommerce-delivery-notes/templates/print-order/print-content.php
@@ -185,7 +185,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 											<dd>
 											<?php
 											// translators: files count.
-											printf( esc_attr_e( '%s Files', 'woocommerce-delivery-notes' ), count( $item->get_item_downloads() ) );
+											printf( esc_attr__( '%s Files', 'woocommerce-delivery-notes' ), count( $item->get_item_downloads() ) );
 											?>
 											</dd>
 


### PR DESCRIPTION
When printing receipts, the number of downloaded files is displayed as "%s files".