### PR TITLE
Make order item object key available in foreach loop

### DIFF
--- a/woocommerce-delivery-notes/templates/print-order/print-content.php
+++ b/woocommerce-delivery-notes/templates/print-order/print-content.php
@@ -104,7 +104,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				if ( count( $order->get_items() ) > 0 ) :
 					?>
-					<?php foreach ( $order->get_items() as $item ) : ?>
+					<?php foreach ( $order->get_items() as $item_id => $item ) : ?>
 
 						<?php
 


### PR DESCRIPTION
The key is useful for functions that require $item_id. For instance, $order->get_qty_refunded_for_item($item_id) to get refunded qty for an item.