### PR TITLE
issue-162

### DIFF
--- a/woocommerce-delivery-notes/templates/print-order/print-content.php
+++ b/woocommerce-delivery-notes/templates/print-order/print-content.php
@@ -139,11 +139,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 									</span>
 
 									<?php
-
+									$item_meta_fields = apply_filters( 'wcdn_product_meta_data', $item['item_meta'], $item );
 									if ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', '>=' ) ) {
 										if ( isset( $item['variation_id'] ) && 0 !== $item['variation_id'] ) {
 											$variation = wc_get_product( $item['product_id'] );
-											foreach ( $item['item_meta'] as $key => $value ) {
+											foreach ( $item_meta_fields as $key => $value ) {
 												if ( ! ( 0 === strpos( $key, '_' ) ) ) {
 													if ( is_array( $value ) ) {
 														continue;
@@ -158,7 +158,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 												}
 											}
 										} else {
-											foreach ( $item['item_meta'] as $key => $value ) {
+											foreach ( $item_meta_fields as $key => $value ) {
 												if ( ! ( 0 === strpos( $key, '_' ) ) ) {
 													if ( is_array( $value ) ) {
 														continue;
@@ -168,7 +168,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 											}
 										}
 									} else {
-										$item_meta_new = new WC_Order_Item_Meta( $item['item_meta'], $product );
+										$item_meta_new = new WC_Order_Item_Meta( $item_meta_fields, $product );
 										$item_meta_new->display();
 
 									}


### PR DESCRIPTION
Added filter to remove/add the product meta data in the invoice.

Example of using the filter:
`add_filter( 'wcdn_product_meta_data', 'example_remove_meta_field' );
function example_remove_meta_field( $fields ) {
	unset( $fields['Text'] );
	return $fields;
}`
https://prnt.sc/22pnwyg
https://prnt.sc/22poh6s

Fix #162