### PR TITLE
Removed the labels for shipping and billing address.

### DIFF
--- a/includes/class-woocommerce-delivery-notes.php
+++ b/includes/class-woocommerce-delivery-notes.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes' ) ) {
 		 *
 		 * @var string $plugin_version Current plugin version number
 		 */
-		public static $plugin_version = '4.7.0';
+		public static $plugin_version = '4.7.1';
 
 		/**
 		 * Plugin URL on current installation

--- a/readme.txt
+++ b/readme.txt
@@ -338,6 +338,9 @@ Please [contribute your translation](https://github.com/TycheSoftwares/woocommer
 
 == Changelog ==
 
+= 4.7.1 (07.12.2022) =
+* Fix :- Fix :- Removed the labels for shipping and billing address. This was added in 4.7.0, which is now reverted back.
+
 = 4.7.0 (06.12.2022) =
 * Fix :- Logo was not showing on Android phone earlier. This is fixed now.
 * Fix :- Display labels for shipping and billing address

--- a/woocommerce-delivery-notes.php
+++ b/woocommerce-delivery-notes.php
@@ -5,7 +5,7 @@
  * Plugin Name: Print Invoice & Delivery Notes for WooCommerce
  * Plugin URI: https://www.tychesoftwares.com/
  * Description: Print Invoices & Delivery Notes for WooCommerce Orders.
- * Version: 4.7.0
+ * Version: 4.7.1
  * Author: Tyche Softwares
  * Author URI: https://www.tychesoftwares.com/
  * License: GPLv3 or later


### PR DESCRIPTION
 This was added in 4.7.0, which is now reverted back.