### PR TITLE
Fix #284

### DIFF
--- a/templates/print-order/print-content.php
+++ b/templates/print-order/print-content.php
@@ -140,8 +140,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 									</span>
 
 									<?php
-									$item_meta_fields = apply_filters( 'wcdn_product_meta_data', $item['item_meta'], $item );
-
+									$item_meta_fields = wc_display_item_meta( $item, apply_filters( 'wcdn_product_meta_data', $item['item_meta'], $item ) );
+									if ( null === $item_meta_fields ) {
+										$item_meta_fields = array();
+									}
 									$product_addons            = array();
 									$woocommerce_product_addon = 'woocommerce-product-addons/woocommerce-product-addons.php';
 									if ( in_array( $woocommerce_product_addon, apply_filters( 'active_plugins', get_option( 'active_plugins', array() ) ), true ) ) {


### PR DESCRIPTION
Fix #284 In this issue, Product metadata is not showing properly. I have added wc_display_item_meta for adding the correct metadata in the product. wc_display_item_meta removed in #224 issue, I have tested the WooCommerce Product Add-ons Plugin, and now it will work properly with updated code.