### PR TITLE
Fixed HPOS Compatibility

### DIFF
--- a/woocommerce-delivery-notes.php
+++ b/woocommerce-delivery-notes.php
@@ -62,6 +62,7 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes' ) ) {
 		function() {
 			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'woocommerce-delivery-notes/woocommerce-delivery-notes.php', true );
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'orders_cache', 'woocommerce-delivery-notes/woocommerce-delivery-notes.php', true );
 			}
 		}
 	);


### PR DESCRIPTION
Fix #300. This issue occurred due to the renamed folder. However, we added this line as it is included in all our other plugins. If WooCommerce has this feature, it should be added.