### PR TITLE
Fixed Payment Received stamp is not working in receipt templates setting

### DIFF
--- a/templates/print-order/simple/receipt/print-content.php
+++ b/templates/print-order/simple/receipt/print-content.php
@@ -142,6 +142,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 </div><!-- .order-addresses -->
 
 <div class="order-info">
+	<?php
+	if ( isset( $data['payment_received_stamp']['active'] ) ) {
+
+		// Specify watermark text.
+		$text = $data['payment_received_stamp']['payment_received_stamp_text'];
+
+		?>
+		<div class="order-stamp-container">
+			<?php echo $text; ?>
+		</div>
+		<?php
+	}
+	?>
 	<ul class="info-list">
 		<?php
 		$fields = apply_filters( 'wcdn_order_info_fields', wcdn_get_order_info( $order, 'receipt' ), $order );

--- a/templates/print-order/simple/style.css
+++ b/templates/print-order/simple/style.css
@@ -142,6 +142,17 @@ tfoot {
 	float: left;
 }
 
+.order-info li strong {
+	min-width: 18%;
+	font-weight: normal;
+	display: inline-block;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	margin-bottom: 0;
+	padding-right: 0.35em;
+}
+
 .order-notes,
 .order-thanks,
 .order-colophon,


### PR DESCRIPTION
Fix #316. When the simple template is active, a payment received stamp is now added to the admin side receipt print link.