### PR TITLE
Fixed Disable all the field when the default template is selected.

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -157,10 +157,16 @@ jQuery(document).ready(function($) {
 	});
 
 	$(document).ready(function(){
-		$('.accordion-button').click(function(){
-			$(this).closest('.accordion-item').toggleClass('expanded');
-		});
+		var initialValue = $('select[name*="[template_setting][template_setting_template]"]').val();
+		if (initialValue == 'default') {
+			$('.accordion-button').click(function(){
+				$(this).closest('.accordion-item').toggleClass('expanded');
+			});
+			$('.accordion-button').attr('disabled', true);
+			$('.accordion-item .switch').css('pointer-events', 'none');
+		}
 	});
+
 	
 	$('select[name*="\\[template_setting\\][\\template_setting_template\\]"]').change(function () {
 		if( this.value == 'simple' ) {


### PR DESCRIPTION
Fix #322. I have added a check to block all fields when the default type is selected or clicked.

